### PR TITLE
mb-footer: only delete <p>s if they are empty.

### DIFF
--- a/mb-plugins/footer/footer.js
+++ b/mb-plugins/footer/footer.js
@@ -28,7 +28,9 @@ var RevealFooter = (function(){
                 if (parent.nodeName == "P")
                 {
                     slide.appendChild(footer);
-                    parent.parentElement.removeChild(parent);
+                    if (parent.childNodes.length == 0) {
+                        parent.parentElement.removeChild(parent);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Sometimes the <p> will not only contain the footer, but also some other
elements that should not be deleted after moving out the footer node.