### PR TITLE
Load font-awesome via reveal.js-menu.

### DIFF
--- a/slide-build/template.html
+++ b/slide-build/template.html
@@ -20,9 +20,6 @@
 	<!-- Theme of AG CG (derived from reveal's white.css) -->
 	<link rel="stylesheet" href="$template$/css/agcg.css">
 
-    <!-- font needed for whiteboard plugin's buttons and menu -->
-    <link rel="stylesheet" href="$template$/Font-Awesome/css/all.css">
-
 	<!-- Setup code formatting with highlight.js -->
 	<link rel="stylesheet" href="$template$/mb-plugins/highlight/xcode.css">
 
@@ -186,7 +183,7 @@ $endif$
         openButton:        false,
         openSlideNumber:   true,
         keyboard:          true,
-        loadIcons:         false
+        loadIcons:         true, // load font-awesome
       },
 
 


### PR DESCRIPTION
If this is sufficient for our purposes, we wouldn't need the
Font-Awesome submodule anymore.