### PR TITLE
Use relative url to mb-plugins in .gitmodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/FortAwesome/Font-Awesome.git
 [submodule "mb-plugins"]
 	path = mb-plugins
-	url = https://github.com/mbotsch/mb-reveal-plugins.git
+	url = ../mb-reveal-plugins.git


### PR DESCRIPTION
This makes it easier to host a local mirror of both repositories.